### PR TITLE
Fix header visibility and home styling

### DIFF
--- a/2025_KECE231-02_Classnotes.html
+++ b/2025_KECE231-02_Classnotes.html
@@ -3,25 +3,59 @@
 
 <head>
 	<meta charset="utf-8">
-	<title>2025 KECE231-02 Class Notes</title>
-	<link rel="preconnect" href="https://fonts.googleapis.com">
-	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-	<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="style.css" />
-<script defer src="script.js"></script>
+        <title>2025 KECE231-02 Class Notes</title>
+        <link rel="icon" href="image/logo.svg" />
+        <link rel="apple_touch_icon" href="image/logo.svg" />
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="style.css" />
+        <script defer src="script.js"></script>
 </head>
 
 <body>
-	<nav class="navigationbar top">
-		<div class="title">
-			<a href="/index.html">
-				<img class="logo" src="image/logo.svg" alt="Mango_">
-				<span class="title_text">Mango_</span>
-			</a>
-		</div>
-	</nav>
-	<div class="container">
-		<div class="content">
+        <nav class="navigationbar scrolled">
+                <div class="title">
+                        <a href="/index.html">
+                                <img class="logo" src="image/logo.svg" alt="Mango_">
+                                <span class="title_text">Mango_ </span>
+                        </a>
+                </div>
+                <div class="menu">
+                        <ul id="item_menu">
+                                <li class="menu_items">
+                                        <a href="/index.html#home">
+                                                <img class="icon" src="image/home.svg" alt="Home">
+                                                <span class="text">Home</span></a>
+                                </li>
+                                <li class="menu_items">
+                                        <a href="/index.html#about">
+                                                <img class="icon" src="image/about.svg" alt="About">
+                                                <span class="text">About</span></a>
+                                </li>
+                                <li class="menu_items">
+                                        <a href="/index.html#contribute">
+                                                <img class="icon" src="image/contribute.svg" alt="Contribute">
+                                                <span class="text">Contribute</span></a>
+                                </li>
+                        </ul>
+                        <ul id="fab_menu">
+                                <li class="fab fa_github">
+                                        <a href="https://github.com/Mango-Clark" target="_blank">
+                                                <img class="fab_icon" src="image/github.svg" alt="GitHub">
+                                        </a>
+                                </li>
+                                <li class="fab fa_chzzk">
+                                        <a href="https://chzzk.naver.com/28b369c6f232eb4773d5b1c35f119cfb" target="_blank">
+                                                <img class="fab_icon" src="image/chzzk.png" alt="Chzzk">
+                                        </a>
+                                </li>
+                        </ul>
+                        <i class="fas fa_bars"><img src="image/hamburger.svg" alt="hamburger"></i>
+                </div>
+        </nav>
+        <div class="container">
+                <div class="content back-home-box">
 			<p><a href="/index.html">Back to home</a></p>
 		</div>
         </div>

--- a/style.css
+++ b/style.css
@@ -171,7 +171,11 @@ body {
 }
 
 .gitlabicons>a {
-	color: var(--secondary-link-color);
-	font-style: italic;
-	text-shadow: 1px 1px 2px var(--text-color);
+        color: var(--secondary-link-color);
+        font-style: italic;
+        text-shadow: 1px 1px 2px var(--text-color);
+}
+
+.back-home-box {
+        background-color: white;
 }


### PR DESCRIPTION
## Summary
- add favicon links to 2025 class notes
- include full navigation bar on the class notes page
- keep header opaque by default
- give the Back to home box a white background

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684347b5ea48832092a668d73b8eaf15