### PR TITLE
Fix apple-touch-icon attribute

### DIFF
--- a/2025_KECE231-02_Classnotes.html
+++ b/2025_KECE231-02_Classnotes.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
         <title>2025 KECE231-02 Class Notes</title>
         <link rel="icon" href="image/logo.svg" />
-        <link rel="apple_touch_icon" href="image/logo.svg" />
+        <link rel="apple-touch-icon" href="image/logo.svg" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">

--- a/classnotes.html
+++ b/classnotes.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<title>망고_의 홈페이지</title>
 	<link rel="icon" href="image/logo.svg" />
-	<link rel="apple_touch_icon" href="image/logo.svg" />
+	<link rel="apple-touch-icon" href="image/logo.svg" />
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<meta charset="utf-8">
 	<title>망고_의 홈페이지</title>
 	<link rel="icon" href="image/logo.svg" />
-	<link rel="apple_touch_icon" href="image/logo.svg" />
+	<link rel="apple-touch-icon" href="image/logo.svg" />
 	<link rel="preconnect" href="https://fonts.googleapis.com">
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 	<link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- correct `apple_touch_icon` attribute to `apple-touch-icon` in HTML files

## Testing
- `npm test` *(fails: Missing script)*
- `python3 -m http.server 8000 &` and `curl -I http://localhost:8000/image/logo.svg`

------
https://chatgpt.com/codex/tasks/task_e_6843a58f0abc83209c45995a2e663ed4